### PR TITLE
simplify dockerfile, update Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 FROM golang:1.21 as builder
 WORKDIR /workspace
+ARG ldflags="-X 'main.Version=unknown'"
 
 # cache deps to the extent possible
 COPY go.mod go.sum ./
 RUN go mod download
 
 # copy and compile code
-COPY .git/ ./.git/
 COPY cmd/ ./cmd/
 COPY internal/ ./internal/
 COPY pkg/ ./pkg/
 COPY package/ ./package/
 COPY Makefile ./
-RUN make build
+RUN make build ldflags="${ldflags}"
 
 FROM busybox:latest as packager
 WORKDIR /package
@@ -30,5 +30,4 @@ FROM scratch as runner
 WORKDIR /
 COPY --from=packager /output/ /
 EXPOSE 9443
-USER nonroot:nonroot
 ENTRYPOINT [ "/xp-function-cue", "server" ]

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@
 image?=gotwarlost/crossplane-function-cue
 
 build_date:=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-commit:=$(shell git rev-parse --short HEAD)
-version:=$(shell git describe --tags --exact-match --match='v*' 2> /dev/null || git symbolic-ref -q --short HEAD || latest)
-ldflags:=-X 'main.BuildDate=$(build_date)' -X 'main.Commit=$(commit)' -X 'main.Version=$(version)'
+commit:=$(shell git rev-parse --short HEAD 2> /dev/null)
+version:=$(shell git describe --tags --exact-match --match='v*' 2> /dev/null || echo latest)
+ldflags?=-X 'main.BuildDate=$(build_date)' -X 'main.Commit=$(commit)' -X 'main.Version=$(version)'
 
 .PHONY: local
 local: build test lint
@@ -46,9 +46,13 @@ test:
 lint: .bin/golangci-lint
 	./.bin/golangci-lint run
 
+.PHONY: docker-build
+docker-build:
+	docker build --tag $(image):$(version) --build-arg "ldflags=$(ldflags)" .
+
 .PHONY: docker
 docker:
-	docker build --tag $(image):$(version) .
+	make -C . docker-build
 
 .PHONY: docker-push
 docker-push: docker


### PR DESCRIPTION
* do not require the `.git` directory to be mounted into the container
* pass in ldflags before `docker build` is invoked