### PR TITLE
add per-instance debugging, improve logging tags

### DIFF
--- a/internal/fn/fn_test.go
+++ b/internal/fn/fn_test.go
@@ -40,7 +40,14 @@ func makeRequest(t *testing.T) *fnv1beta1.RunFunctionRequest {
 	"meta": { "tag": "v1" },
     "observed": {
         "composite": {
-            "resource": { "foo": "bar" },
+            "resource": {
+				"apiVersion": "v1",
+				"kind": "MyKind",
+				"metadata": {
+					"annotations": { "crossplane-function-cue/debug": "true" }
+				},
+				"foo": "bar" 
+			},
 			"ready": 0
         }
     },


### PR DESCRIPTION
* Respect an annotation called `crossplane-function-cue/debug` on the observed composite. When set to `"true"` debugging is turned on for that request even if otherwise turned off.
* Add tags to the logger based on observed composite, similar to other function implementations.