### PR TITLE
add ttl and debugNew knobs in the input spec

### DIFF
--- a/pkg/input/v1beta1/input.go
+++ b/pkg/input/v1beta1/input.go
@@ -46,12 +46,25 @@ type CueInputSpec struct {
 	// Script specifies an inline script
 	// +optional
 	Script string `json:"script,omitempty"`
-	// Debug prints inputs to and outputs of the cue script.
+	// TTL is a duration string which, when set, will cause the function to set the TTL
+	// for reconciliation to be the specified value. Defaults to 1m.
+	// +optional
+	TTL string `json:"ttl,omitempty"`
+	// Debug prints inputs to and outputs of the cue script for all XRs.
 	// Inputs are pre-processed to remove typically irrelevant information like
 	// the last applied kubectl annotation, managed fields etc.
 	// Objects are displayed in compact cue format. (the equivalent of `cue fmt -s`)
+	// When false, individual XRs can still be debugged by annotation them with
+	//    crossplane-function-cue/debug: "true"
 	// +optional
 	Debug bool `json:"debug,omitempty"`
+	// DebugNew controls whether a new XR that is being processed by the function
+	// has debug output. A "new" XR is determined by the request having only an
+	// observed composite but no other observed resources. This allows debug output for
+	// first-time reconciles of XRs when the user has not yet had the opportunity to
+	// annotate them.
+	// +optional
+	DebugNew bool `json:"debugNew,omitempty"`
 	// DebugRaw disables the pre-processing of inputs.
 	// +optional
 	DebugRaw bool `json:"debugRaw,omitempty"`


### PR DESCRIPTION
* ttl allows the user to define the TTL for reconciles which was currently hardcoded to the default value of 1m
* debugNew allows new XRs that enter the system to be debugged without having to turn global debugging on