### PR TITLE
qualify image name with docker.io/

### DIFF
--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -21,7 +21,7 @@ CUE_VERSION?=v0.7.0
 DYFF_VERSION?=v1.7.0
 
 FN_CUE_VERSION?=latest
-FN_IMAGE:=gotwarlost/crossplane-function-cue
+FN_IMAGE:=docker.io/gotwarlost/crossplane-function-cue
 
 MAKE=make --no-print-directory
 

--- a/examples/simple/helm/zz_generated/functions.yaml
+++ b/examples/simple/helm/zz_generated/functions.yaml
@@ -1,7 +1,7 @@
 metadata:
   name: fn-cue-examples-simple
 spec:
-  package: gotwarlost/crossplane-function-cue:latest
+  package: docker.io/gotwarlost/crossplane-function-cue:latest
   packagePullPolicy: Always
 kind: Function
 apiVersion: pkg.crossplane.io/v1beta1


### PR DESCRIPTION
Looks like the latest crossplane requires a specific prefix without which it defaults to a crossplane-specific repo